### PR TITLE
fix: escape double quotes in logline JSON formatter

### DIFF
--- a/parser/search.go
+++ b/parser/search.go
@@ -41,7 +41,7 @@ func formatLine(query *sqlquery.QueryParams, line []byte) []byte {
 			} else if res.Type == gjson.Null {
 				selectedEntries = append(selectedEntries, `"`+keyName+`":null`)
 			} else {
-				selectedEntries = append(selectedEntries, `"`+keyName+`":"`+res.String()+`"`)
+				selectedEntries = append(selectedEntries, `"`+keyName+`":"`+strings.Replace(res.String(), `"`, `\"`, -1)+`"`)
 			}
 		}
 


### PR DESCRIPTION
In the manual function used for building the JSON emitted for log lines to stdout, double quotes are not being escaped, producing invalid JSON.